### PR TITLE
feat: Add Aquaman to sample superheroes data

### DIFF
--- a/superheroes/management/commands/populate_superheroes.py
+++ b/superheroes/management/commands/populate_superheroes.py
@@ -235,7 +235,24 @@ class Command(BaseCommand):
                 "universe": "Marvel",
                 "is_active": True,
                 "is_villain": False,
-            }
+            },
+
+            {
+            "name": "Aquaman",
+            "real_name": "Arthur Curry",
+            "alias": "King of Atlantis",
+            "age": 35,
+            "height": Decimal("185.00"),
+            "weight": Decimal("107.00"),
+            "powers": "Superhuman strength, durability, control over marine life, can breathe underwater, expert swimmer",
+            "power_level": 9,
+            "origin_story": (
+                "Son of a human lighthouse keeper and the queen of Atlantis, raised to be the bridge between the surface world and the sea"
+            ),
+            "universe": "DC",
+            "is_active": True,
+            "is_villain": False,
+        }
 
         ]
 


### PR DESCRIPTION
Added Aquaman (Arthur Curry) to the sample superheroes data.
- Universe: DC
- Powers: Super strength, marine life control, underwater breathing
- Power Level: 9

This enhancement expands the dataset with another major DC superhero as per Issue #29.