### PR TITLE
Critical Bug Fix: ValueError in top_superheroes Action

### DIFF
--- a/superheroes/views.py
+++ b/superheroes/views.py
@@ -106,7 +106,9 @@ class SuperheroViewSet(ModelViewSet):
     def top_superheroes(self, request):
         """Get top superheroes by power level."""
         try:
-            limit = int(request.query_params.get("limit", 10))
+            limit = int(request.query_params.get("limit", 10)) 
+            if limit < 0:
+                raise ValueError("Invalid value for 'limit'. Must be an positive integrer")   
         except ValueError:
             return Response(
                 {"error": "Invalid value for 'limit'. Must be an integer."},


### PR DESCRIPTION
Issue : https://github.com/CyrilBaah/Superheroes-API/issues/33
The limit parameter is fetched from the request's query parameters, but if a user provides a value that cannot be converted to an integer (e.g., ?limit=five), the line limit = int(request.query_params.get("limit", 10)) will raise a ValueError, causing a 500 Server Error instead of a proper 400 Bad Request response.

The solution is to wrap the type conversion in a try...except block. This will catch the ValueError and allow you to return a clean, user-friendly error message.